### PR TITLE
.github/ports_psoc6.yml: Updated checkout action to v3.

### DIFF
--- a/.github/workflows/ports_psoc6.yml
+++ b/.github/workflows/ports_psoc6.yml
@@ -21,7 +21,7 @@ jobs:
     outputs:
       commit_sha: ${{ steps.commit_sha.outputs.sha_short }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install packages
         run: source tools/ci.sh && ci_psoc6_setup
       - name: Build
@@ -43,7 +43,7 @@ jobs:
       matrix:
         board: [CY8CPROTO-062-4343W]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Download binaries
       uses: actions/download-artifact@v3
     - name: Setup device


### PR DESCRIPTION
v2 using deprecated node.js version