### PR TITLE
ports/psoc6 : Fixed scan function in network module.

### DIFF
--- a/ports/psoc6/main.c
+++ b/ports/psoc6/main.c
@@ -12,7 +12,7 @@
 #include "cyhal.h"
 #include "cy_wcm.h"
 
-/* FreeRTOS header file */
+// FreeRTOS header file
 #include <FreeRTOS.h>
 #include <task.h>
 #include <queue.h>
@@ -106,11 +106,6 @@ void mpy_task(void *arg) {
     network_ifx_init();
     #endif
 
-    /*#if MICROPY_PY_NETWORK
-    cy_wcm_config_t wcm_config = { .interface = CY_WCM_INTERFACE_TYPE_STA };
-    cy_wcm_init(&wcm_config);
-    #endif*/
-
 soft_reset:
 
     mp_init();
@@ -178,7 +173,7 @@ soft_reset:
     goto soft_reset;
 }
 
-// // TODO: to be implemented
+// TODO: to be implemented
 void nlr_jump_fail(void *val) {
     mplogger_print("nlr_jump_fail\n");
 
@@ -189,6 +184,3 @@ void nlr_jump_fail(void *val) {
         __BKPT(0);
     }
 }
-
-
-

--- a/ports/psoc6/main.c
+++ b/ports/psoc6/main.c
@@ -49,6 +49,7 @@ extern void time_init(void);
 extern void os_init(void);
 extern void machine_init(void);
 extern void machine_deinit(void);
+extern void network_ifx_init(void);
 
 void mpy_task(void *arg);
 
@@ -101,11 +102,14 @@ void mpy_task(void *arg) {
     os_init();
     rtc_init();
     time_init();
-
     #if MICROPY_PY_NETWORK
+    network_ifx_init();
+    #endif
+
+    /*#if MICROPY_PY_NETWORK
     cy_wcm_config_t wcm_config = { .interface = CY_WCM_INTERFACE_TYPE_STA };
     cy_wcm_init(&wcm_config);
-    #endif
+    #endif*/
 
 soft_reset:
 
@@ -185,3 +189,6 @@ void nlr_jump_fail(void *val) {
         __BKPT(0);
     }
 }
+
+
+

--- a/ports/psoc6/modules/network/network_ifx_whd.h
+++ b/ports/psoc6/modules/network/network_ifx_whd.h
@@ -27,9 +27,108 @@
 #ifndef MICROPY_INCLUDED_EXTMOD_NETWORK_IFX_WHD_H
 #define MICROPY_INCLUDED_EXTMOD_NETWORK_IFX_WHD_H
 
+#include "FreeRTOS.h"
+#include "task.h"
+#include "cy_wcm.h"
+#include <stdio.h>
+
+/*******************************************************************************
+ * Macros
+ ******************************************************************************/
+
+/* Provide the value of SSID which should be used to filter the scan results.*/
+#define SCAN_FOR_SSID_VALUE                     "SSID"
+
+/* Provide the value of the MAC address which should be used to filter the scan
+ * results. For example, MAC Address: 12:34:56:78:9A:BC should be entered as
+ * shown below.
+ */
+#define SCAN_FOR_MAC_ADDRESS                     0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC
+
+/* Provide the value of the ISM band (2.4 GHz/ 5 GHz/ both) which should be used
+ * to filter the scan results. The valid values are provided in the enumeration
+ * cy_wcm_wifi_band_t in cy_wcm.h.
+ * Note: CY8CPROTO-062-4343W is a single band device and can only scan for
+ * networks in 2.4 GHz.
+ */
+#define SCAN_FOR_BAND_VALUE                     CY_WCM_WIFI_BAND_ANY
+
+/* Provide the value of the RSSI range that should be used to filter the scan
+ * results. The valid values are provided in the enumeration
+ * cy_wcm_scan_rssi_range_t in cy_wcm.h.
+ */
+#define SCAN_FOR_RSSI_VALUE                     CY_WCM_SCAN_RSSI_EXCELLENT
+
+/* The delay in milliseconds between successive scans.*/
+#define SCAN_DELAY_MS                           (3000u)
+
+#define SCAN_TASK_STACK_SIZE                    (4096u)
+#define SCAN_TASK_PRIORITY                      (3u)
+
+#define MAX_SECURITY_STRING_LENGTH              (15)
+
+#define SECURITY_OPEN                           "OPEN"
+#define SECURITY_WEP_PSK                        "WEP-PSK"
+#define SECURITY_WEP_SHARED                     "WEP-SHARED"
+#define SECURITY_WEP_TKIP_PSK                   "WEP-TKIP-PSK"
+#define SECURITY_WPA_TKIP_PSK                   "WPA-TKIP-PSK"
+#define SECURITY_WPA_AES_PSK                    "WPA-AES-PSK"
+#define SECURITY_WPA_MIXED_PSK                  "WPA-MIXED-PSK"
+#define SECURITY_WPA2_AES_PSK                   "WPA2-AES-PSK"
+#define SECURITY_WPA2_TKIP_PSK                  "WPA2-TKIP-PSK"
+#define SECURITY_WPA2_MIXED_PSK                 "WPA2-MIXED-PSK"
+#define SECURITY_WPA2_FBT_PSK                   "WPA2-FBT-PSK"
+#define SECURITY_WPA3_SAE                       "WPA3-SAE"
+#define SECURITY_WPA2_WPA_AES_PSK               "WPA2-WPA-AES-PSK"
+#define SECURITY_WPA2_WPA_MIXED_PSK             "WPA2-WPA-MIXED-PSK"
+#define SECURITY_WPA3_WPA2_PSK                  "WPA3-WPA2-PSK"
+#define SECURITY_WPA_TKIP_ENT                   "WPA-TKIP-ENT"
+#define SECURITY_WPA_AES_ENT                    "WPA-AES-ENT"
+#define SECURITY_WPA_MIXED_ENT                  "WPA-MIXED-ENT"
+#define SECURITY_WPA2_TKIP_ENT                  "WPA2-TKIP-ENT"
+#define SECURITY_WPA2_AES_ENT                   "WPA2-AES-ENT"
+#define SECURITY_WPA2_MIXED_ENT                 "WPA2-MIXED-ENT"
+#define SECURITY_WPA2_FBT_ENT                   "WPA2-FBT-ENT"
+#define SECURITY_IBSS_OPEN                      "IBSS-OPEN"
+#define SECURITY_WPS_SECURE                     "WPS-SECURE"
+#define SECURITY_UNKNOWN                        "UNKNOWN"
+
+#define PRINT_SCAN_TEMPLATE()                   printf("\n----------------------------------------------------------------------------------------------------\n" \
+    "  #                  SSID                  RSSI   Channel       MAC Address              Security\n" \
+    "----------------------------------------------------------------------------------------------------\n");
+
+#define APP_INFO(x)           do { printf("\nInfo: "); printf x;} while (0);
+#define ERR_INFO(x)           do { printf("\nError: "); printf x;} while (0);
+
+/*******************************************************************************
+ * Enumerations
+ ******************************************************************************/
+/* This enumeration contains the different types of scan filters available. They
+ * are,
+ * SCAN_FILTER_NONE: No scan filter.
+ * SCAN_FILTER_SSID: The scan results are filtered by SSID.
+ * SCAN_FILTER_MAC: The scan results are filtered by MAC address of the AP.
+ * SCAN_FILTER_BAND: The scan results are filtered by the ISM band (2.4 or 5 GHz
+ * or both) that the AP is occupying.
+ * SCAN_FILTER_RSSI: The scan results are filtered by the RSSI strength.
+ * SCAN_FILTER_INVALID: Invalid scan filter.
+ */
+enum scan_filter_mode
+{
+    SCAN_FILTER_NONE = 0,
+    SCAN_FILTER_SSID,
+    SCAN_FILTER_MAC,
+    SCAN_FILTER_BAND,
+    SCAN_FILTER_RSSI,
+    SCAN_FILTER_INVALID
+};
+
 extern const mp_obj_type_t mp_network_ifx_whd_type;
 extern whd_driver_t whd;
 extern whd_interface_t itf_sta;
 extern whd_interface_t itf_ap;
+
+void network_ifx_init(void);
+void error_handler(cy_rslt_t result, char *message);
 
 #endif // MICROPY_INCLUDED_EXTMOD_NETWORK_IFX_WHD_H


### PR DESCRIPTION
I have already taken the changes contributed to network modules and added scan function and init related part. All works for me now.

**Few points to note:**
1. Our stack has lot more breakdown on security type while mpy conventions ask to classify them to 5:
There are five values for security:
0 – open
1 – WEP
2 – WPA-PSK
3 – WPA2-PSK
4 – WPA/WPA2-PSK
But this is not enough for certain types like "WPA3..." or "UNKNOWN" types. And hence, I had to end up extending the mpy convention to more values. This should be taken care while we document it.

2. network_ifx_whd_print() has to be later fixed by rendering right status information. Currently, it does not block our progress and has low priority. Ticket for the same is in backlog.


